### PR TITLE
[Issue #25] Updated syntax highlighting registration method.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -54,3 +54,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/11/09, parrt, Terence Parr, parrt@antlr.org
 2019/01/16, syakovlevdalet, Sergey Yakovlev, syakovlev@dalet.com
 2019/01/17, bjansen, Bastien Jansen, bastien.jansen@gmx.com
+2020/05/19, FHannes, Frédéric Hannes, frederic.hannes@gmail.com

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginVersion=0.7
 
 # e.g. IC-2016.3.3, IU-2018.2.5 etc
 # For a list of possible values, refer to the section 'com.jetbrains.intellij.idea' at https://www.jetbrains.com/intellij-repository/releases
-ideaVersion=2019.3
+ideaVersion=2020.1
 
 # The version of ANTLR v4 that will be used to generate the parser
 antlr4Version=4.7.2

--- a/src/main/java/org/antlr/jetbrains/st4plugin/highlight/STGroupHighlightingPassFactory.java
+++ b/src/main/java/org/antlr/jetbrains/st4plugin/highlight/STGroupHighlightingPassFactory.java
@@ -2,26 +2,21 @@ package org.antlr.jetbrains.st4plugin.highlight;
 
 import com.intellij.codeHighlighting.TextEditorHighlightingPass;
 import com.intellij.codeHighlighting.TextEditorHighlightingPassFactory;
+import com.intellij.codeHighlighting.TextEditorHighlightingPassFactoryRegistrar;
 import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar;
-import com.intellij.openapi.components.AbstractProjectComponent;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class STGroupHighlightingPassFactory
-	extends AbstractProjectComponent
-	implements TextEditorHighlightingPassFactory
+	implements TextEditorHighlightingPassFactory, TextEditorHighlightingPassFactoryRegistrar
 {
-	public STGroupHighlightingPassFactory(Project project,
-	                                      TextEditorHighlightingPassRegistrar registrar)
-	{
-		super(project);
-		registrar.registerTextEditorHighlightingPass(this, null, null, true, -1);
-	}
+	private Project project;
 
 	@Nullable
 	@Override
@@ -30,6 +25,13 @@ public class STGroupHighlightingPassFactory
 		Document doc = editor.getDocument();
 		VirtualFile vfile = FileDocumentManager.getInstance().getFile(doc);
 		if ( vfile==null || !vfile.getName().endsWith(".stg") ) return null;
-		return new STGroupHighlightingPass(myProject, editor);
+		return new STGroupHighlightingPass(project, editor);
 	}
+
+	@Override
+	public void registerHighlightingPassFactory(@NotNull TextEditorHighlightingPassRegistrar registrar, @NotNull Project project) {
+		this.project = project;
+		registrar.registerTextEditorHighlightingPass(this, null, null, true, -1);
+	}
+
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,9 +37,6 @@
 	  <component>
        <implementation-class>org.antlr.jetbrains.st4plugin.STGroupPluginController</implementation-class>
    </component>
-    <component>
-        <implementation-class>org.antlr.jetbrains.st4plugin.highlight.STGroupHighlightingPassFactory</implementation-class>
-    </component>
   </project-components>
 
   <actions>
@@ -50,6 +47,7 @@
       <structureViewBuilder factoryClass="org.antlr.jetbrains.st4plugin.structview.STGroupStructureViewBuilderProvider"/>
       <additionalTextAttributes scheme="Default" file="colorSchemes/STGroupDefault.xml"/>
    	  <additionalTextAttributes scheme="Darcula" file="colorSchemes/STGroupDarcula.xml"/>
+      <highlightingPassFactory implementation="org.antlr.jetbrains.st4plugin.highlight.STGroupHighlightingPassFactory"/>
 
       <lang.parserDefinition language="STGroup" implementationClass="org.antlr.jetbrains.st4plugin.psi.STGroupParserDefinition"/>
       <lang.foldingBuilder language="STGroup" implementationClass="org.antlr.jetbrains.st4plugin.folding.STGroupFoldingBuilder"/>


### PR DESCRIPTION
This is not backwards compatible with versions of IntelliJ older than 192.3645. Might need some additional work if it should be and/or some way of forcing the minimum version of the IDE to use the plugin.