### PR TITLE
Make compatible with IntelliJ versions 2022.3+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.6.5"
+    id "org.jetbrains.intellij" version "1.15.0"
 }
 
 apply plugin: 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -16,21 +16,21 @@ apply plugin: 'antlr'
 intellij {
     version = ideaVersion
 
-    pluginName 'jetbrains-plugin-st4'
-    downloadSources true
-    updateSinceUntilBuild false
+    pluginName = 'jetbrains-plugin-st4'
+    downloadSources = true
+    updateSinceUntilBuild = false
 }
 
 group 'antlr'
 version pluginVersion
 
 wrapper {
-    gradleVersion = "6.0.1"
+    gradleVersion = "8.3"
 }
 
 compileJava {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    sourceCompatibility = '17'
+    targetCompatibility = '17'
 }
 sourceSets {
     main.antlr.includes = ["ST*.g4"]

--- a/contributors.txt
+++ b/contributors.txt
@@ -55,3 +55,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/01/16, syakovlevdalet, Sergey Yakovlev, syakovlev@dalet.com
 2019/01/17, bjansen, Bastien Jansen, bastien.jansen@gmx.com
 2020/05/19, FHannes, Frédéric Hannes, frederic.hannes@gmail.com
+2023/08/23, daithiscully, David Scully, davidscully129@gmail.com

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginVersion=0.10-SNAPSHOT
 
 # e.g. IC-2016.3.3, IU-2018.2.5 etc
 # For a list of possible values, refer to the section 'com.jetbrains.intellij.idea' at https://www.jetbrains.com/intellij-repository/releases
-ideaVersion=2020.2
+ideaVersion=2022.3
 
 # The version of ANTLR v4 that will be used to generate the parser
 antlr4Version=4.9

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Just bumped versions to make IntelliJ happy. No code changes done though there are some deprecated methods in use.